### PR TITLE
Add issues to project board

### DIFF
--- a/.github/workflows/my-workflow.yml
+++ b/.github/workflows/my-workflow.yml
@@ -18,3 +18,8 @@ jobs:
               repo: context.repo.repo,
               body: "🎉 You've created this issue comment using GitHub Script!!!"
             })
+            github.projects.createCard({
+            column_id: 12792729,
+            content_id: context.payload.issue.id,
+            content_type: "Issue"
+            });


### PR DESCRIPTION
The workflow will now automatically comment on a created issue, before creating a card with the issue in the project board.

Although this is not a course on octokit/rest.js, it is important to tell you a little secret right here before we move on. For you to be able to use the `projects.createCard()` method there were some pieces of information we needed beforehand. Things like the `column_id` so we know which column to add the card to and even a `project_id` so we know which board that column belongs to.

We've gone ahead and done this on our end of things so that we could give you the final piece to the puzzle and demonstrate how to use GitHub Script. So if you try to recreate this on your own, without the help of Learning Lab you will need to get that information and parse it in a way that works well for your use case!